### PR TITLE
Problem with nested array

### DIFF
--- a/lib/deep_fetch/core_ext.rb
+++ b/lib/deep_fetch/core_ext.rb
@@ -7,7 +7,11 @@ class Hash
       value.deep_fetch(*args, &block)
     elsif value.kind_of?(Array) && args.size > 0
       value = value[args.shift]
-      value.deep_fetch(*args, &block)
+      if args.size > 0
+        value.deep_fetch(*args, &block)
+      else
+        value
+      end
     elsif args.size > 0
       {}.fetch(args.shift, &block)
     else

--- a/spec/deep_fetch_spec.rb
+++ b/spec/deep_fetch_spec.rb
@@ -40,6 +40,10 @@ describe Hash do
       it "of hash from deeper hash" do
         {:foo => {:bar => {:baz => :boo}}}.deep_fetch(:foo, :bar).must_equal({:baz => :boo})
       end
+
+      it "from nested array" do
+        {:foo => {:bar => [:baz]}}.deep_fetch(:foo, :bar, 0).must_equal(:baz)
+      end
     end
 
     describe "must rise KeyError" do


### PR DESCRIPTION
I've got such a hash:

``` ruby
h = {
  :errors => {
    :base => [:some_error]
  }
}
```

When I call `h.deep_fetch(:errors, :base, 0)` I'm receiving an error:

> NoMethodError: undefined method `deep_fetch' for :some_error:Symbol
