### PR TITLE
deep_fetch fails in accessing something other than Hash in Array

### DIFF
--- a/lib/deep_fetch/core_ext.rb
+++ b/lib/deep_fetch/core_ext.rb
@@ -12,7 +12,7 @@ class Hash
       elsif value.kind_of?(Array)
         value = value[arg]
       else
-        {}.fetch(arg, &block)
+        value = {}.fetch(arg, &block)
       end
     end
 

--- a/lib/deep_fetch/core_ext.rb
+++ b/lib/deep_fetch/core_ext.rb
@@ -2,22 +2,20 @@ class Hash
   def deep_fetch *args, &block
     raise ArgumentError.new("wrong number of arguments (0 for 1..n)") if args.empty?
 
-    value = fetch(args.shift, &block)
-    if args.size > 0
+    value = self
+
+    while args.size > 0
+      arg = args.shift
+
       if value.kind_of?(Hash)
-        value.deep_fetch(*args, &block)
+        value = value.fetch(arg, &block)
       elsif value.kind_of?(Array)
-        value = value[args.shift]
-        if args.size > 0
-          value.deep_fetch(*args, &block)
-        else
-          value
-        end
+        value = value[arg]
       else
-        {}.fetch(args.shift, &block)
+        {}.fetch(arg, &block)
       end
-    else
-      value
     end
+
+    value
   end
 end

--- a/spec/deep_fetch_spec.rb
+++ b/spec/deep_fetch_spec.rb
@@ -45,6 +45,10 @@ describe Hash do
         {:foo => {:bar => [:baz]}}.deep_fetch(:foo, :bar, 0).must_equal(:baz)
       end
 
+      it "from array in array" do
+        {:foo => [:bar, [:baz]]}.deep_fetch(:foo, 1, 0).must_equal(:baz)
+      end
+
       it "of hash from deeper hash from nested array" do
         {:foo => {:bar => [{:baz => :boo}]}}.deep_fetch(:foo, :bar, 0).must_equal({:baz => :boo})
       end


### PR DESCRIPTION
When you access something other than hash in array (`{:foo => [:bar, [:baz]]}.deep_fetch(:foo, 1, 0){:default_value}`), it raises NoMethodError because `[:baz]` doesn't have `deep_fetch` method.

This pull request fixes this problem by using loop instead of recursive call of deep_fetch.
