### PR TITLE
Silence warning on running `rake test`

### DIFF
--- a/spec/deep_fetch_spec.rb
+++ b/spec/deep_fetch_spec.rb
@@ -1,5 +1,5 @@
-require 'minitest/spec'
 require 'minitest/autorun'
+require 'minitest/spec'
 
 require File.expand_path('../../lib/deep_fetch', __FILE__)
 require 'coveralls'


### PR DESCRIPTION
When we run `rake test`, it warns:

```
Warning: you should require 'minitest/autorun' instead.
Warning: or add 'gem "minitest"' before 'require "minitest/autorun"'
```

This patch removes the warnings.
